### PR TITLE
Bugfix: #21 - Explicitly use `h5netcdf` engine in `xr.open_dataset()`

### DIFF
--- a/agrifoodpy_data/food/__init__.py
+++ b/agrifoodpy_data/food/__init__.py
@@ -15,11 +15,11 @@ def __getattr__(name):
     # If the file contains more than a single dataarray, then it will try
     # to load it as a dataset
     try:
-        with xr.open_dataset(_data_file) as data:
+        with xr.open_dataset(_data_file, engine="h5netcdf") as data:
             data.load()
             return data
         
     except ValueError:
-        with xr.open_dataarray(_data_file) as data:
+        with xr.open_dataarray(_data_file, engine="h5netcdf") as data:
             data.load()
             return data

--- a/agrifoodpy_data/impact/__init__.py
+++ b/agrifoodpy_data/impact/__init__.py
@@ -15,11 +15,11 @@ def __getattr__(name):
     # If the file contains more than a single dataarray, then it will try
     # to load it as a dataset
     try:
-        with xr.open_dataset(_data_file) as data:
+        with xr.open_dataset(_data_file, engine="h5netcdf") as data:
             data.load()
             return data
         
     except ValueError:
-        with xr.open_dataarray(_data_file) as data:
+        with xr.open_dataarray(_data_file, engine="h5netcdf") as data:
             data.load()
             return data

--- a/agrifoodpy_data/land/__init__.py
+++ b/agrifoodpy_data/land/__init__.py
@@ -26,11 +26,11 @@ def __getattr__(name):
     # If the file contains more than a single dataarray, then it will try
     # to load it as a dataset
     try:
-        with xr.open_dataset(_data_file) as data:
+        with xr.open_dataset(_data_file, engine="h5netcdf") as data:
             data.load()
             return data
         
     except ValueError:
-        with xr.open_dataarray(_data_file) as data:
+        with xr.open_dataarray(_data_file, engine="h5netcdf") as data:
             data.load()
             return data

--- a/agrifoodpy_data/population/__init__.py
+++ b/agrifoodpy_data/population/__init__.py
@@ -15,11 +15,11 @@ def __getattr__(name):
     # If the file contains more than a single dataarray, then it will try
     # to load it as a dataset
     try:
-        with xr.open_dataset(_data_file) as data:
+        with xr.open_dataset(_data_file, engine="h5netcdf") as data:
             data.load()
             return data
         
     except ValueError:
-        with xr.open_dataarray(_data_file) as data:
+        with xr.open_dataarray(_data_file, engine="h5netcdf") as data:
             data.load()
             return data

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ INSTALL_REQUIRES = [
       'pandas',
       'xarray',
       'matplotlib',
-      'netcdf4'
+      'netcdf4',
+      'hdf5',
+      'cftime'
 ]
 
 setup(name=PACKAGE_NAME,


### PR DESCRIPTION
Fixes #21 

## Changes
- Add `engine="h5netcdf"` to `xr.open_dataset()` in `__init__.py` files for opening `.nc` data
- Add `hdf5` and `cftime` explicitly in dependencies

## NOTICE
Please test this before merging, I'm getting some weird behaviour on MacOS and don't have a Linux machine to test it on